### PR TITLE
Fix: add missing default parameters to cache resolver save method

### DIFF
--- a/src/Lib/CacheResolver.php
+++ b/src/Lib/CacheResolver.php
@@ -16,13 +16,21 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StaticResolverBundle\Lib;
 
+use DateInterval;
 use Pimcore\Cache;
 
 class CacheResolver
 {
-    public function save(mixed $data, string $key, array $tags = []): void
+    public function save(
+        mixed $data,
+        string $key,
+        array $tags = [],
+        DateInterval|int $lifetime = null,
+        int $priority = 0,
+        bool $force = false
+    ): void
     {
-        Cache::save($data, $key, $tags);
+        Cache::save($data, $key, $tags, $lifetime, $priority, $force);
     }
 
     public function load(string $key): mixed


### PR DESCRIPTION
## Changes in this pull request
Resolves #

## Additional info

### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough