### PR TITLE
Remove Copilot for Pull Requests from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,11 +2,3 @@
 Resolves #
 
 ## Additional info
-
-### WHAT
-copilot:summary
-
-copilot:poem
-
-### HOW
-copilot:walkthrough


### PR DESCRIPTION
## Changes in this pull request
It's deprecated and will conclude on December 15, see: [githubnext.com/copilot-for-prs-sunset](https://githubnext.com/copilot-for-prs-sunset)

See https://github.com/pimcore/pimcore/pull/16271

## Additional info

### WHAT
copilot:summary

copilot:poem

### HOW
copilot:walkthrough