### PR TITLE
Removed unnecessary return type EncryptedField

### DIFF
--- a/src/Models/DataObject/ClassDefinitionServiceResolver.php
+++ b/src/Models/DataObject/ClassDefinitionServiceResolver.php
@@ -18,7 +18,6 @@ namespace Pimcore\Bundle\StaticResolverBundle\Models\DataObject;
 
 use Pimcore\Bundle\StaticResolverBundle\Contract\Models\DataObject\ClassDefinitionServiceResolverContract;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
-use Pimcore\Model\DataObject\ClassDefinition\Data\EncryptedField;
 use Pimcore\Model\DataObject\ClassDefinition\Layout;
 use Pimcore\Model\DataObject\ClassDefinition\Service;
 
@@ -31,7 +30,7 @@ final class ClassDefinitionServiceResolver extends ClassDefinitionServiceResolve
         array $array,
         bool $throwException = false,
         bool $insideLocalizedField = false
-    ): EncryptedField|bool|Data|Layout {
+    ): bool|Data|Layout {
         return Service::generateLayoutTreeFromArray($array, $throwException, $insideLocalizedField);
     }
 

--- a/src/Models/DataObject/ClassDefinitionServiceResolverInterface.php
+++ b/src/Models/DataObject/ClassDefinitionServiceResolverInterface.php
@@ -19,7 +19,6 @@ namespace Pimcore\Bundle\StaticResolverBundle\Models\DataObject;
 use Exception;
 use Pimcore\Bundle\StaticResolverBundle\Contract\Models\DataObject\ClassDefinitionServiceResolverContractInterface;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
-use Pimcore\Model\DataObject\ClassDefinition\Data\EncryptedField;
 use Pimcore\Model\DataObject\ClassDefinition\Layout;
 
 /**
@@ -34,7 +33,7 @@ interface ClassDefinitionServiceResolverInterface extends ClassDefinitionService
         array $array,
         bool $throwException = false,
         bool $insideLocalizedField = false
-    ): EncryptedField|bool|Data|Layout;
+    ): bool|Data|Layout;
 
     public function setDoRemoveDynamicOptions(bool $doRemoveDynamicOptions): void;
 

--- a/src/Models/DataObject/ClassificationStore/ServiceResolver.php
+++ b/src/Models/DataObject/ClassificationStore/ServiceResolver.php
@@ -16,7 +16,6 @@ declare(strict_types=1);
 
 namespace Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassificationStore;
 
-use Exception;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
 use Pimcore\Model\DataObject\Classificationstore\KeyConfig;
 use Pimcore\Model\DataObject\Classificationstore\KeyGroupRelation;

--- a/src/Models/DataObject/ClassificationStore/ServiceResolver.php
+++ b/src/Models/DataObject/ClassificationStore/ServiceResolver.php
@@ -32,9 +32,6 @@ final class ServiceResolver implements ServiceResolverInterface
         Service::clearDefinitionsCache();
     }
 
-    /**
-     * @throws Exception
-     */
     public function getFieldDefinitionFromKeyConfig(
         KeyConfig|KeyGroupRelation $keyConfig
     ): ?Data {

--- a/src/Models/DataObject/ClassificationStore/ServiceResolver.php
+++ b/src/Models/DataObject/ClassificationStore/ServiceResolver.php
@@ -37,11 +37,11 @@ final class ServiceResolver implements ServiceResolverInterface
      */
     public function getFieldDefinitionFromKeyConfig(
         KeyConfig|KeyGroupRelation $keyConfig
-    ): Data|null {
+    ): ?Data {
         return Service::getFieldDefinitionFromKeyConfig($keyConfig);
     }
 
-    public function getFieldDefinitionFromJson(array $definition, string $type): Data|null
+    public function getFieldDefinitionFromJson(array $definition, string $type): ?Data
     {
         return Service::getFieldDefinitionFromJson($definition, $type);
     }

--- a/src/Models/DataObject/ClassificationStore/ServiceResolver.php
+++ b/src/Models/DataObject/ClassificationStore/ServiceResolver.php
@@ -18,7 +18,6 @@ namespace Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassificationSt
 
 use Exception;
 use Pimcore\Model\DataObject\ClassDefinition\Data;
-use Pimcore\Model\DataObject\ClassDefinition\Data\EncryptedField;
 use Pimcore\Model\DataObject\Classificationstore\KeyConfig;
 use Pimcore\Model\DataObject\Classificationstore\KeyGroupRelation;
 use Pimcore\Model\DataObject\Classificationstore\Service;
@@ -38,11 +37,11 @@ final class ServiceResolver implements ServiceResolverInterface
      */
     public function getFieldDefinitionFromKeyConfig(
         KeyConfig|KeyGroupRelation $keyConfig
-    ): EncryptedField|Data|null {
+    ): Data|null {
         return Service::getFieldDefinitionFromKeyConfig($keyConfig);
     }
 
-    public function getFieldDefinitionFromJson(array $definition, string $type): EncryptedField|Data|null
+    public function getFieldDefinitionFromJson(array $definition, string $type): Data|null
     {
         return Service::getFieldDefinitionFromJson($definition, $type);
     }

--- a/src/Models/DataObject/ClassificationStore/ServiceResolverInterface.php
+++ b/src/Models/DataObject/ClassificationStore/ServiceResolverInterface.php
@@ -29,7 +29,7 @@ interface ServiceResolverInterface
 
     public function getFieldDefinitionFromKeyConfig(
         KeyConfig|KeyGroupRelation $keyConfig
-    ): Data|null;
+    ): ?Data;
 
-    public function getFieldDefinitionFromJson(array $definition, string $type): Data|null;
+    public function getFieldDefinitionFromJson(array $definition, string $type): ?Data;
 }

--- a/src/Models/DataObject/ClassificationStore/ServiceResolverInterface.php
+++ b/src/Models/DataObject/ClassificationStore/ServiceResolverInterface.php
@@ -17,7 +17,6 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\StaticResolverBundle\Models\DataObject\ClassificationStore;
 
 use Pimcore\Model\DataObject\ClassDefinition\Data;
-use Pimcore\Model\DataObject\ClassDefinition\Data\EncryptedField;
 use Pimcore\Model\DataObject\Classificationstore\KeyConfig;
 use Pimcore\Model\DataObject\Classificationstore\KeyGroupRelation;
 
@@ -30,7 +29,7 @@ interface ServiceResolverInterface
 
     public function getFieldDefinitionFromKeyConfig(
         KeyConfig|KeyGroupRelation $keyConfig
-    ): EncryptedField|Data|null;
+    ): Data|null;
 
-    public function getFieldDefinitionFromJson(array $definition, string $type): EncryptedField|Data|null;
+    public function getFieldDefinitionFromJson(array $definition, string $type): Data|null;
 }


### PR DESCRIPTION
`EncryptedField` is also part of `Data`.  `Data` type is enough.

See also: https://github.com/pimcore/pimcore/pull/18272